### PR TITLE
chore: run database migrations on container startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,4 +10,4 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 
 COPY . .
 
-CMD ["gunicorn", "config.wsgi:application", "--bind", "0.0.0.0:8000"]
+CMD ["sh", "-c", "python manage.py migrate && gunicorn config.wsgi:application --bind 0.0.0.0:8000"]


### PR DESCRIPTION
This update ensures that Django database migrations are executed automatically every time the container starts in production.

Changes include:
- Modified the Dockerfile to run `python manage.py migrate` before launching Gunicorn.
- Ensures smoother deployment on Render, especially in the free tier where shell access is not available.
- Fixes 500 errors caused by missing database tables after initial deployment.

This change makes the backend ready for production use without manual intervention.